### PR TITLE
docs: Correct link in google analytics example

### DIFF
--- a/examples/google-analytics/README.md
+++ b/examples/google-analytics/README.md
@@ -12,7 +12,7 @@ Open this example on [CodeSandbox](https://codesandbox.com):
 
 This example shows how to use Google analytics with Remix.
 
-First you have to get the Google analytics ID and add that key in the [app/utils/gtags.ts](./app/utils/gtags.ts) file.
+First you have to get the Google analytics ID and add that key in the [app/utils/gtags.ts](./app/utils/gtags.client.ts) file.
 
 Check [app/root.tsx](./app/root.tsx) where page tracking code is added. For tracking events check [app/routes/contact.tsx](./app/routes/contact.tsx) file.
 


### PR DESCRIPTION
Corrects a broken link in the existing google analytics readme. 